### PR TITLE
feat: allow to extend provided words

### DIFF
--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { generate } from "./generate.js";
 import adjectives from "./words/adjectives.js";
@@ -40,7 +40,7 @@ describe("generate", () => {
 		expect(nouns).toContain(noun);
 	});
 
-	describe("with color option", () => {
+	describe("with withColor option", () => {
 		it("returns a string with no spaces when withColor is true", () => {
 			const response = generate({ withColor: true });
 
@@ -80,6 +80,129 @@ describe("generate", () => {
 
 			const noun = response.split("-")[2];
 			expect(nouns).toContain(noun);
+		});
+	});
+
+	describe("with adjectives option", () => {
+		it("returns a string with no spaces when adjectives are provided", () => {
+			const response = generate({ adjectives: () => ["good", "cool"] });
+
+			expect(response).not.toContain(" ");
+		});
+
+		it("returns a string with one of the specified adjectives", () => {
+			const response = generate({ adjectives: () => ["good", "nice"] });
+
+			const adjective = response.split("-")[0];
+			expect(["good", "nice"]).toContain(adjective);
+		});
+
+		it("passes the exsiting adjectives", () => {
+			const fn = vi.fn(() => ["good", "nice"]);
+			generate({ adjectives: fn });
+
+			expect(fn).toHaveBeenCalledWith(adjectives);
+		});
+
+		it("returns a string with the second word from nouns", () => {
+			const response = generate({ adjectives: () => ["good", "nice"] });
+
+			const noun = response.split("-")[1];
+			expect(nouns).toContain(noun);
+		});
+	});
+
+	describe("with nouns option", () => {
+		it("returns a string with no spaces when nouns are provided", () => {
+			const response = generate({ nouns: () => ["energy", "vibe"] });
+
+			expect(response).not.toContain(" ");
+		});
+
+		it("returns a string with one of the specified nouns", () => {
+			const response = generate({ nouns: () => ["energy", "vibe"] });
+
+			const noun = response.split("-")[1];
+			expect(["energy", "vibe"]).toContain(noun);
+		});
+
+		it("passes the exsiting nouns", () => {
+			const fn = vi.fn(() => ["energy", "vibe"]);
+			generate({ nouns: fn });
+
+			expect(fn).toHaveBeenCalledWith(nouns);
+		});
+
+		it("returns a string with the first word from adjectives", () => {
+			const response = generate({ nouns: () => ["energy", "vibe"] });
+
+			const adjective = response.split("-")[0];
+			expect(adjectives).toContain(adjective);
+		});
+	});
+
+	describe("with colors option", () => {
+		it("returns a string with no spaces when colors are provided", () => {
+			const response = generate({
+				colors: () => ["hazel", "rainbow"],
+				withColor: true,
+			});
+
+			expect(response).not.toContain(" ");
+		});
+
+		it("returns a string with one of the specified colors", () => {
+			const response = generate({
+				colors: () => ["hazel", "rainbow"],
+				withColor: true,
+			});
+
+			const color = response.split("-")[0];
+			expect(["hazel", "rainbow"]).toContain(color);
+		});
+
+		it("passes the exsiting colors", () => {
+			const fn = vi.fn(() => ["hazel", "rainbow"]);
+			generate({ colors: fn, withColor: true });
+
+			expect(fn).toHaveBeenCalledWith(colors);
+		});
+
+		it("returns a string with the second word from adjectives", () => {
+			const response = generate({
+				colors: () => ["hazel", "rainbow"],
+				withColor: true,
+			});
+
+			const adjective = response.split("-")[1];
+			expect(adjectives).toContain(adjective);
+		});
+
+		it("returns a string with the third word from nouns", () => {
+			const response = generate({
+				colors: () => ["hazel", "rainbow"],
+				withColor: true,
+			});
+
+			const noun = response.split("-")[2];
+			expect(nouns).toContain(noun);
+		});
+
+		it("returns a string with one dash when withColor is false", () => {
+			const response = generate({
+				colors: () => ["hazel", "rainbow"],
+				withColor: false,
+			});
+
+			const dashCount = response.split("-").length - 1;
+			expect(dashCount).toBe(1);
+		});
+
+		it("returns a string with one dash when withColor is unset", () => {
+			const response = generate({ colors: () => ["hazel", "rainbow"] });
+
+			const dashCount = response.split("-").length - 1;
+			expect(dashCount).toBe(1);
 		});
 	});
 });

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -4,6 +4,9 @@ import colors from "./words/colors.js";
 
 interface GenerateOptions {
 	withColor?: boolean;
+	adjectives?: (adjectives: string[]) => string[];
+	nouns?: (nouns: string[]) => string[];
+	colors?: (colors: string[]) => string[];
 }
 
 const getRandomWord = (list: string[]): string => {
@@ -13,11 +16,14 @@ const getRandomWord = (list: string[]): string => {
 };
 
 export const generate = (options: GenerateOptions = {}) => {
-	const adjective = getRandomWord(adjectives);
-	const noun = getRandomWord(nouns);
+	const allAdjectives = options.adjectives?.(adjectives) ?? adjectives;
+	const adjective = getRandomWord(allAdjectives);
+	const allNouns = options.nouns?.(nouns) ?? nouns;
+	const noun = getRandomWord(allNouns);
 
 	if (options.withColor) {
-		const color = getRandomWord(colors);
+		const allColors = options.colors?.(colors) ?? colors;
+		const color = getRandomWord(allColors);
 		return color + "-" + adjective + "-" + noun;
 	}
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to name-gen! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/FarazPatankar/name-gen/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/FarazPatankar/name-gen/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds 3 new optional options `adjectives`, `nouns` and `colors` which allows to extend or override the provided words.

The options are functions, as a simple way to extend or override the existing words as a single convenient option.

Example:

```ts
generate({
  adjectives: (adjectives) => [...adjectives, 'tasty'], // extend all adjectives
  nouns: () => ['coffee'], // override nouns with custom nouns
})
```